### PR TITLE
install_python_packages.sh: No such file

### DIFF
--- a/scripts/install_scripts/virtualenv_setup.sh
+++ b/scripts/install_scripts/virtualenv_setup.sh
@@ -68,5 +68,5 @@ fi
 
 
 workon $project_name
-cd "$my_dirname"
-bash install_python_packages.sh >virtualenv_setup.out 2>virtualenv_setup.err
+wget https://bootstrap.pypa.io/get-pip.py -O- | python
+pip install -r $requirements_filename


### PR DESCRIPTION
virtualenv setup script is looking for an install script that doesn't exist. I assume that it's trying to run an old equivalent of the pip requirements file.