### PR TITLE
_r time function variants don't exist in Windows

### DIFF
--- a/cpp_code/src/DateTime.cpp
+++ b/cpp_code/src/DateTime.cpp
@@ -33,11 +33,19 @@ using namespace std;
 
 string DateTime::GetDateTimeStr() {
     time_t rawtime;
-    struct tm timeinfo;
     char buffer[30];
     time(&rawtime);
+
+#ifdef _WIN32
+    struct tm *timeinfo;
+    timeinfo = localtime(&rawtime);
+    strcpy(buffer,asctime(timeinfo));
+#else
+    struct tm timeinfo;
     ::localtime_r(&rawtime, &timeinfo);
     ::asctime_r(&timeinfo, buffer) ;
+#endif
+
     int len = ::strlen(buffer);
     buffer[len - 1] = 0x00;
     return buffer;


### PR DESCRIPTION
localtime_r and asctime_r are POSIX only, but the original forms
should be thread-safe in Windows because they use thread-local
storage.