### PR TITLE
remove 'broke' print statement

### DIFF
--- a/crosscat/tests/quality_tests/synthetic_data_generator.py
+++ b/crosscat/tests/quality_tests/synthetic_data_generator.py
@@ -116,7 +116,6 @@ def generate_separated_multinomial_weights(A,C):
 			maxdex = numpy.argmin(lower_bounds)
 			B[maxdex] = 0
 			B /= numpy.sum(B)
-			print('Broke')
 			break
 
 		move_down = dns[random.randrange(len(dns))]


### PR DESCRIPTION
the 'broke' refers to the code breaking from a loop, rather than actual code being broken. Either way, it is not necessary.