### PR TITLE
Fsaad conditional pdf fixes issue #47

### DIFF
--- a/crosscat/tests/crash/test_pred_prob.py
+++ b/crosscat/tests/crash/test_pred_prob.py
@@ -1,0 +1,158 @@
+#
+#   Copyright (c) 2010-2014, MIT Probabilistic Computing Project
+#
+#   Lead Developers: Dan Lovell and Jay Baxter
+#   Authors: Dan Lovell, Baxter Eaves, Jay Baxter, Vikash Mansinghka
+#   Research Leads: Vikash Mansinghka, Patrick Shafto
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import argparse
+import pytest
+import random
+import sys
+import tempfile
+
+import numpy
+
+from crosscat.tests.quality_tests import synthetic_data_generator as sdg
+from crosscat.LocalEngine import LocalEngine
+import crosscat.cython_code.State as State
+
+'''
+This test suite ensures that invoking simple_predictive_probability_observed
+and simple_predictive_probability_unobserved from sample_utils.py with various
+constraint Y and query Q patterns does not throw runtime errors.
+
+TODO:
+    Whether simple_predictive_probability performs the 'correct' computation
+    is not addressed by this test. The design choices for what it means to
+    condition on observed/unobserved members is not documented anywhere in
+    the repository and must be reverse engineered from the spaghetti code.
+
+    Unfortunatley, there is no one place to figure out how the constraints Y
+    are being used in the evaluation of the predictive probability. The most
+    important functions which indicate how conditional constraints are used are:
+
+        sample_utils.py
+            - def get_draw_constraints(X_L, X_D, Y, draw_row, draw_column)
+            - def def get_cluster_sampling_constraints(Y, query_row)
+
+        ComponentModel.h
+            - get_draw_constrained(int random_seed,
+                    const std::vector<double>& constraints) const;
+            - calc_element_predictive_logp_constrained(double element,
+                const std::vector<double>& constraints) const;
+
+        It is not entirely clear
+            - What is the probabilistic reasoning behind the code that takes
+                [Y, Q] and produces constraint_dict?
+            - How are the constraints marshalled between Python and CPP?
+            - When conditioning on a cell in observed row, do we delete the
+                already observed value?
+            - Why can we not condition one unobserved on another unobserved?
+                This behaviior throws a RuntimeError (tested below).
+'''
+
+N_ROWS = 1000
+
+def quick_le(seed, n_chains=1):
+    # Specify synthetic dataset structure.
+    cctypes = ['continuous', 'continuous', 'multinomial', 'multinomial',
+        'continuous']
+    distargs = [None, None, dict(K=9), dict(K=7), None]
+    cols_to_views = [0, 0, 0, 1, 1]
+    separation = [0.6, 0.9]
+    cluster_weights = [[.2, .3, .5],[.9, .1]]
+
+    # Obtain the generated dataset and metadata/
+    T, M_c, M_r = sdg.gen_data(cctypes, N_ROWS, cols_to_views, cluster_weights,
+        separation, seed=seed, distargs=distargs, return_structure=True)
+
+    # Create, initialize, and analyze the engine.
+    engine = LocalEngine(seed=seed)
+    X_L, X_D = engine.initialize(M_c, M_r, T, n_chains=n_chains)
+
+    return T, M_r, M_c, X_L, X_D, engine
+
+def simple_predictive_probability_observed():
+    # TODO
+    pass
+
+def simple_predictive_probability_unobserved(seed=0):
+    T, M_r, M_c, X_L, X_D, engine = quick_le(seed)
+
+    # Must query unobserved rows. CrossCat can only assess same row. We will
+    # query one numerical column 0 and categorical column 2.
+    Q = [[(N_ROWS, 0, 0.5)], [(N_ROWS, 2, 1)]]
+
+
+    # Specify complex pattern of reasonable constraints. These tests demonstrate
+    # desired behavior (no crashes), and were addressed in the branch
+    # fsaad-conditional-pdf
+    Y = [(0, 0, 1), (N_ROWS/2, 4, 5), (N_ROWS, 1, 0.5), (N_ROWS+1, 0, 1.2)]
+    # - Numerical column Q[0].
+    vals = engine.simple_predictive_probability(M_c, X_L, X_D, Y, Q[0])
+    # - Categorical column Q[1].
+    vals = engine.simple_predictive_probability(M_c, X_L, X_D, Y, Q[1])
+
+
+    # XXX TODO: Fix more issues discovered
+    # Thenext  queries are probabilistically sound, but the code demonstrates
+    # bizarre behavior. Determing what to do in all of these special cases is
+    # a design problem.
+
+
+    # Query the cell P(N_ROWS,0)=0.5 GIVEN (N_ROWS,0)==0.5
+    # A reasonable human would expect this logp = log(1) = 0... guess not...
+
+    # - Numerical cell Q[0].
+    Y = [(N_ROWS, 0, 0.5)]
+    val = engine.simple_predictive_probability(M_c, X_L, X_D, Y, Q[0])
+    with pytest.raises(AssertionError):
+        assert val[0] == 0
+
+    # - Categorical cell Q[1].
+    Y = [(N_ROWS, 2, 1)]
+    val = engine.simple_predictive_probability(M_c, X_L, X_D, Y, Q[1])
+    with pytest.raises(AssertionError):
+        assert val[0] == 0
+
+
+    # Query a hypothetical cell, constraining on another hypothetical row with
+    # values in a DIFFERENT column as the column of the query cell.
+    # This test does not cause a crash.
+
+    # - Numerical cell Q[0]
+    Y = [(N_ROWS, 0, 1.5), (N_ROWS+1, 1, 1.5)]
+    vals = engine.simple_predictive_probability(M_c, X_L, X_D, Y, Q[0])
+
+    # - Categorical cell Q[1]
+    Y = [(N_ROWS, 2, 4), (N_ROWS+1, 3, 5)]
+    vals = engine.simple_predictive_probability(M_c, X_L, X_D, Y, Q[1])
+
+
+    # Query a hypothetical cell, constraining on another hypothetical row with
+    # values in a SAME column as the column of the query cell.
+    # This causes an IndexError ...
+
+    # - Numerical cell Q[0]
+    Y = [(N_ROWS, 0, 1.5), (N_ROWS+1, 0, 2)]
+    with pytest.raises(IndexError):
+        vals = engine.simple_predictive_probability(M_c, X_L, X_D, Y, Q[0])
+
+    # - Numerical cell Q[1]
+    Y = [(N_ROWS, 2, 4), (N_ROWS+1, 2, 5)]
+    with pytest.raises(IndexError):
+        vals = engine.simple_predictive_probability(M_c, X_L, X_D, Y, Q[1])

--- a/crosscat/tests/crash/test_pred_prob.py
+++ b/crosscat/tests/crash/test_pred_prob.py
@@ -36,10 +36,11 @@ and simple_predictive_probability_unobserved from sample_utils.py with various
 constraint Y and query Q patterns does not throw runtime errors.
 
 TODO:
-    Whether simple_predictive_probability performs the 'correct' computation
-    is not addressed by this test. The design choices for what it means to
-    condition on observed/unobserved members is not documented anywhere in
-    the repository and must be reverse engineered from the spaghetti code.
+    Whether simple_predictive_probability performs the 'correct' computation in
+    carefully constructed cases is not addressed by this test. The design
+    choices for what it means to condition on observed/unobserved members is not
+    documented anywhere in the repository and must be reverse engineered from
+    the spaghetti code.
 
     Unfortunatley, there is no one place to figure out how the constraints Y
     are being used in the evaluation of the predictive probability. The most
@@ -62,7 +63,7 @@ TODO:
             - When conditioning on a cell in observed row, do we delete the
                 already observed value?
             - Why can we not condition one unobserved on another unobserved?
-                This behaviior throws a RuntimeError (tested below).
+                This behavior throws a RuntimeError (tested below).
 '''
 
 N_ROWS = 1000
@@ -109,7 +110,7 @@ def simple_predictive_probability_unobserved(seed=0):
 
 
     # XXX TODO: Fix more issues discovered
-    # Thenext  queries are probabilistically sound, but the code demonstrates
+    # The next queries are probabilistically sound, but the code demonstrates
     # bizarre behavior. Determing what to do in all of these special cases is
     # a design problem.
 

--- a/crosscat/utils/sample_utils.py
+++ b/crosscat/utils/sample_utils.py
@@ -490,8 +490,19 @@ def determine_cluster_logps(M_c, X_L, X_D, Y, query_row, view_idx):
     cluster_data_logps = determine_cluster_data_logps(M_c, X_L, X_D, Y,
                                                       query_row, view_idx)
     cluster_data_logps = numpy.array(cluster_data_logps)
-    #
-    cluster_logps = cluster_crp_logps + cluster_data_logps
+    # We need to compute the vector of probabilities log[P(Z=j|Y)] where `Z`
+    # is the row cluster, `Y` are the constraints, and `j` iterates from 1 to
+    # the number of clusters (plus 1 for a new cluster) in the row partition of
+    # `view_idx`. Mathematically:
+    # log{P(Z=j|Y)} = log{P(Z=j)P(Y|Z=j) / P(Y) }
+    #               = log{P(Z=j)} + log{P(Y|Z=j)} - log{sum_j(P(Z=j)P(Y|Z=j))}
+    #               = cluster_crp_logps + cluster_data_logps - BAZ
+    # The final term BAZ is computed by:
+    # log{sum_j(P(Z=j)P(Y|Z=j))}
+    # = log{sum_j(exp(log{P(Z=j)}+log{P(Y|Z=j)}))
+    # = logsumexp(cluster_crp_logps + cluster_data_logps)
+    cluster_logps = cluster_crp_logps + cluster_data_logps - \
+        logsumexp(cluster_crp_logps + cluster_data_logps)
 
     return cluster_logps
 


### PR DESCRIPTION
This branch fixes issue #47 although it discovers more issues with evaluating densities with constraints (which was blocking development of LL/KL in bayeslite), although the new issues are non-blocking issues (mostly edge cases).

Future branches similar to this one should perform
 - evaluation of multivariate densities [with/without constraints] as a new feature
 - testing simulate [with/without constraints, observed/unobserved rows, uni/multivariate]